### PR TITLE
fix npm install fail due to ts-node dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "aws-cdk": "^1.71.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
-    "ts-node": "^8.1.0",
+    "ts-node": ">=9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {


### PR DESCRIPTION
npm install fail due to ts-node dependency
"ts-node": ">=9.0.0", should fix it